### PR TITLE
Mejora del cálculo del impuesto CCSS

### DIFF
--- a/back-end/back-end/API/TaxCCSSController.cs
+++ b/back-end/back-end/API/TaxCCSSController.cs
@@ -17,12 +17,14 @@ namespace back_end.API
 
         [AllowAnonymous]
         [HttpPost]
-        public IActionResult ComputeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees)
+        public IActionResult ComputeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees, 
+            DateOnly endDate)
         {
             IActionResult iActionResult = BadRequest("Unknown error.");
             try
             {
-                payrollEmployees = taxCCSS.ComputeTaxesCCSS(payrollEmployees);
+                payrollEmployees = taxCCSS.computeTaxesCCSS(payrollEmployees, 
+                    endDate);
                 iActionResult = Ok(payrollEmployees);
             }
             catch (Exception e)

--- a/back-end/back-end/API/TaxCCSSController.cs
+++ b/back-end/back-end/API/TaxCCSSController.cs
@@ -22,8 +22,8 @@ namespace back_end.API
             IActionResult iActionResult = BadRequest("Unknown error.");
             try
             {
-                var taxesCCSS = taxCCSS.ComputeTaxesCCSS(payrollEmployees);
-                iActionResult = Ok(taxesCCSS);
+                payrollEmployees = taxCCSS.ComputeTaxesCCSS(payrollEmployees);
+                iActionResult = Ok(payrollEmployees);
             }
             catch (Exception e)
             {

--- a/back-end/back-end/API/TaxCCSSController.cs
+++ b/back-end/back-end/API/TaxCCSSController.cs
@@ -1,6 +1,5 @@
 ﻿using back_end.Application;
 using back_end.Domain;
-using back_end.Infraestructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,14 +15,14 @@ namespace back_end.API
             taxCCSS = new TaxCCSS();
         }
 
-        [Authorize(Roles = "empleador")]
+        [AllowAnonymous]
         [HttpPost]
-        public IActionResult ComputeTaxesCCSS(List<GrossSalaryModel> grossSalaries)
+        public IActionResult ComputeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees)
         {
             IActionResult iActionResult = BadRequest("Unknown error.");
             try
             {
-                var taxesCCSS = taxCCSS.ComputeTaxesCCSS(grossSalaries);
+                var taxesCCSS = taxCCSS.ComputeTaxesCCSS(payrollEmployees);
                 iActionResult = Ok(taxesCCSS);
             }
             catch (Exception e)

--- a/back-end/back-end/Application/ITaxCCSS.cs
+++ b/back-end/back-end/Application/ITaxCCSS.cs
@@ -4,6 +4,6 @@ namespace back_end.Application
 {
     public interface ITaxCCSS
     {
-        List<TaxCCSSModel> ComputeTaxesCCSS(List<GrossSalaryModel> grossSalaries);
+        List<PayrollEmployeeModel> ComputeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees);
     }
 }

--- a/back-end/back-end/Application/ITaxCCSS.cs
+++ b/back-end/back-end/Application/ITaxCCSS.cs
@@ -4,6 +4,7 @@ namespace back_end.Application
 {
     public interface ITaxCCSS
     {
-        List<PayrollEmployeeModel> ComputeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees);
+        List<PayrollEmployeeModel> computeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees, 
+            DateOnly endDate);
     }
 }

--- a/back-end/back-end/Application/TaxCCSS.cs
+++ b/back-end/back-end/Application/TaxCCSS.cs
@@ -5,9 +5,6 @@ namespace back_end.Application
 {
     public class TaxCCSS : ITaxCCSS
     {
-        private const int GROSS_SALARIES_MINIMUM_SIZE = 1;
-        private const int GROSS_SALARIES_MAXIMUM_SIZE = 1000;
-
         private const double P_VALUE_ON_DECIMAL_SQL_TYPE = 11.0;
         private const double S_VALUE_ON_DECIMAL_SQL_TYPE = 2.0;
         private const double EXPONENTATION_BASE_VALUE_ON_DECIMAL_SQL_TYPE = 10.0;
@@ -17,28 +14,28 @@ namespace back_end.Application
         private const double EMPLOYER_TAX_PERCENT = 0.1467;
         private const double EMPLOYEE_TAX_PERCENT = 0.0967;
 
-        public List<TaxCCSSModel> ComputeTaxesCCSS(List<GrossSalaryModel> grossSalaries)
+        public List<PayrollEmployeeModel> ComputeTaxesCCSS(List<PayrollEmployeeModel> payrollEmployees)
         {
-            var ccssTaxes = new List<TaxCCSSModel>();
-            for (int i = 0; i < grossSalaries.Count; ++i)
+            for (int i = 0; i < payrollEmployees.Count; ++i)
             {
-                var computedResult = ComputeTaxCCSS(grossSalaries[i]);
-                ccssTaxes.Add(computedResult);
+                payrollEmployees[i] = ComputeTaxCCSS(payrollEmployees[i]);
             }
-            return ccssTaxes;
+            return payrollEmployees;
         }
 
-        private TaxCCSSModel ComputeTaxCCSS(GrossSalaryModel grossSalary)
+        private PayrollEmployeeModel ComputeTaxCCSS(PayrollEmployeeModel payrollEmployee)
         {
-            ValidateComputedGrossSalary(grossSalary.ComputedGrossSalary);
+            ValidateComputedGrossSalary(payrollEmployee.computedGrossSalary);
             var employeeTax = 0.0;
             var employerTax = 0.0;
-            if (grossSalary.HiringType != HIRING_TYPE_EXCLUDED_FROM_TAXES)
+            if (payrollEmployee.hiringType != HIRING_TYPE_EXCLUDED_FROM_TAXES)
             {
-                employeeTax = grossSalary.ComputedGrossSalary * EMPLOYEE_TAX_PERCENT;
-                employerTax = grossSalary.ComputedGrossSalary * EMPLOYER_TAX_PERCENT;
+                employeeTax = payrollEmployee.computedGrossSalary * EMPLOYEE_TAX_PERCENT;
+                employerTax = payrollEmployee.computedGrossSalary * EMPLOYER_TAX_PERCENT;
             }
-            return new TaxCCSSModel { EmployeeAmount = employeeTax, EmployerAmount = employerTax };
+            payrollEmployee.ccssEmployeeDeduction = employeeTax;
+            payrollEmployee.ccssEmployerDeduction = employerTax;
+            return payrollEmployee;
         }
 
         private void ValidateComputedGrossSalary(double computedGrossSalary)
@@ -67,18 +64,6 @@ namespace back_end.Application
             if (computedGrossSalary < 0)
             {
                 throw new Exception("The computed gross salary can not be less than zero.");
-            }
-        }
-
-        private void ValidateList(List<GrossSalaryModel> grossSalaries)
-        {
-            if (grossSalaries.Count < GROSS_SALARIES_MINIMUM_SIZE)
-            {
-                throw new Exception("The list most contain at least one GrossSalaryModel");
-            }
-            if (grossSalaries.Count > GROSS_SALARIES_MAXIMUM_SIZE)
-            {
-                throw new Exception("Due to SqlServer limitations: the list can not exceed 1000 models");
             }
         }
     }

--- a/back-end/back-end/Domain/TaxCCSSModel.cs
+++ b/back-end/back-end/Domain/TaxCCSSModel.cs
@@ -1,8 +1,0 @@
-﻿namespace back_end.Domain
-{
-    public class TaxCCSSModel
-    {
-        public required double EmployeeAmount { get; set; }
-        public required double EmployerAmount { get; set; }
-    }
-}


### PR DESCRIPTION
[User Story](https://infinipay.atlassian.net/jira/software/projects/SCRUM/boards/1/backlog?selectedIssue=SCRUM-79)

Se hizo el ajuste para que este módulo use el PayrollEmployeeModel. Además ahora el cálculo si es certero ya que toma en cuenta el caso respecto a la [base mínima contributa](https://www.ccss.sa.cr/noticia?v=patronos-con-trabajadores-menores-a-35-anos-y-reportados-en-jornadas-parciales-pagaran-menos-por-aseguramiento).